### PR TITLE
etcdctl: add diagnosis command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ verify: verify-gofmt verify-bom verify-lint verify-dep verify-shellcheck verify-
 	verify-govet-shadow verify-markdown-marker verify-go-versions
 
 .PHONY: fix
-fix: fix-bom fix-lint fix-yamllint sync-toolchain-directive
+	fix: fix-bom fix-lint fix-yamllint sync-toolchain-directive
 	./scripts/fix.sh
 
 .PHONY: verify-gofmt
@@ -100,7 +100,7 @@ verify-bom:
 	PASSES="bom" ./scripts/test.sh
 
 .PHONY: fix-bom
-fix-bom:
+	fix-bom:
 	./scripts/updatebom.sh
 
 .PHONY: verify-dep
@@ -112,7 +112,7 @@ verify-lint: install-golangci-lint
 	PASSES="lint" ./scripts/test.sh
 
 .PHONY: fix-lint
-fix-lint:
+	fix-lint:
 	PASSES="lint_fix" ./scripts/test.sh
 
 .PHONY: verify-shellcheck
@@ -172,7 +172,7 @@ verify-markdown-marker:
 YAMLFMT_VERSION = $(shell cd tools/mod && go list -m -f '{{.Version}}' github.com/google/yamlfmt)
 
 .PHONY: fix-yamllint
-fix-yamllint:
+	fix-yamllint:
 ifeq (, $(shell which yamlfmt))
 	$(shell go install github.com/google/yamlfmt/cmd/yamlfmt@$(YAMLFMT_VERSION))
 endif
@@ -190,9 +190,10 @@ endif
 GOLANGCI_LINT_VERSION = $(shell cd tools/mod && go list -m -f {{.Version}} github.com/golangci/golangci-lint)
 .PHONY: install-golangci-lint
 install-golangci-lint:
-ifeq (, $(shell which golangci-lint))
-	$(shell curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION))
-endif
+	@installed_version=$$(golangci-lint --version 2>/dev/null | awk '{print $$4}' || echo); \
+	if [ "$$installed_version" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
+	fi
 
 .PHONY: install-lazyfs
 install-lazyfs: bin/lazyfs

--- a/etcdctl/README.md
+++ b/etcdctl/README.md
@@ -1129,6 +1129,23 @@ DOWNGRADE CANCEL cancels the ongoing downgrade action to cluster.
 ./etcdctl downgrade cancel
 Downgrade cancel success, cluster version 3.5
 ```
+### DIAGNOSIS <subcommand>
+
+`diagnosis` collects a set of troubleshooting details from every endpoint and
+optionally analyses an etcd data directory when `--offline` is specified.
+The command runs several plugins including membership checks, endpoint status,
+serializable and linearizable reads and a small metrics snapshot.
+
+#### Example
+
+```bash
+# online analysis
+./etcdctl diagnosis --endpoints=http://127.0.0.1:2379
+
+# offline analysis
+./etcdctl diagnosis --offline --data-dir /var/lib/etcd
+```
+
 
 ## Concurrency commands
 

--- a/etcdctl/ctlv3/command/diagnosis_command.go
+++ b/etcdctl/ctlv3/command/diagnosis_command.go
@@ -1,0 +1,86 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/offline"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/epstatus"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/membership"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/metrics"
+	readplugin "go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/read"
+)
+
+var diagCfg = agent.GlobalConfig{}
+
+// NewDiagnosisCommand returns the cobra command for "diagnosis".
+func NewDiagnosisCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diagnosis",
+		Short: "One-stop etcd diagnosis tool",
+		Run:   runDiagnosis,
+	}
+
+	cmd.Flags().StringSliceVar(&diagCfg.Endpoints, "endpoints", []string{"127.0.0.1:2379"}, "comma separated etcd endpoints")
+	cmd.Flags().BoolVar(&diagCfg.UseClusterEndpoints, "cluster", false, "use all endpoints from the cluster member list")
+
+	cmd.Flags().DurationVar(&diagCfg.DialTimeout, "dial-timeout", 2*time.Second, "dial timeout for client connections")
+	cmd.Flags().DurationVar(&diagCfg.CommandTimeout, "command-timeout", 5*time.Second, "command timeout (excluding dial timeout)")
+	cmd.Flags().DurationVar(&diagCfg.KeepAliveTime, "keepalive-time", 2*time.Second, "keepalive time for client connections")
+	cmd.Flags().DurationVar(&diagCfg.KeepAliveTimeout, "keepalive-timeout", 5*time.Second, "keepalive timeout for client connections")
+
+	cmd.Flags().BoolVar(&diagCfg.Insecure, "insecure-transport", true, "disable transport security for client connections")
+	cmd.Flags().BoolVar(&diagCfg.InsecureSkipVerify, "insecure-skip-tls-verify", false, "skip server certificate verification (CAUTION: this option should be enabled only for testing purposes)")
+	cmd.Flags().StringVar(&diagCfg.CertFile, "cert", "", "identify secure client using this TLS certificate file")
+	cmd.Flags().StringVar(&diagCfg.KeyFile, "key", "", "identify secure client using this TLS key file")
+	cmd.Flags().StringVar(&diagCfg.CaFile, "cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle")
+
+	cmd.Flags().StringVar(&diagCfg.Username, "user", "", "username[:password] for authentication (prompt if password is not supplied)")
+	cmd.Flags().StringVar(&diagCfg.Password, "password", "", "password for authentication (if this option is used, --user option shouldn't include password)")
+	cmd.Flags().StringVarP(&diagCfg.DNSDomain, "discovery-srv", "d", "", "domain name to query for SRV records describing cluster endpoints")
+	cmd.Flags().StringVarP(&diagCfg.DNSService, "discovery-srv-name", "", "", "service name to query when using DNS discovery")
+	cmd.Flags().BoolVar(&diagCfg.InsecureDiscovery, "insecure-discovery", true, "accept insecure SRV records describing cluster endpoints")
+
+	cmd.Flags().IntVar(&diagCfg.DbQuotaBytes, "etcd-storage-quota-bytes", 2*1024*1024*1024, "etcd storage quota in bytes (the value passed to etcd instance by flag --quota-backend-bytes)")
+
+	cmd.Flags().BoolVar(&diagCfg.PrintVersion, "version", false, "print the version and exit")
+
+	cmd.Flags().BoolVar(&diagCfg.Offline, "offline", false, "offline analysis")
+	cmd.Flags().StringVar(&diagCfg.DataDir, "data-dir", "", "path to data directory")
+
+	return cmd
+}
+
+func runDiagnosis(cmd *cobra.Command, args []string) {
+	if diagCfg.Offline {
+		offline.AnalyzeOffline(diagCfg.DataDir)
+		return
+	}
+
+	plugins := []intf.Plugin{
+		membership.NewPlugin(diagCfg),
+		epstatus.NewPlugin(diagCfg),
+		readplugin.NewPlugin(diagCfg, false),
+		readplugin.NewPlugin(diagCfg, true),
+		metrics.NewPlugin(diagCfg),
+	}
+	engine.Diagnose(diagCfg, plugins)
+}

--- a/etcdctl/ctlv3/ctl.go
+++ b/etcdctl/ctlv3/ctl.go
@@ -98,6 +98,7 @@ func init() {
 		command.NewUserCommand(),
 		command.NewRoleCommand(),
 		command.NewCheckCommand(),
+		command.NewDiagnosisCommand(),
 		command.NewCompletionCommand(),
 		command.NewDowngradeCommand(),
 	)

--- a/etcdctl/diagnosis/OWNERS
+++ b/etcdctl/diagnosis/OWNERS
@@ -1,0 +1,1 @@
+# See the OWNERS docs at https://go.k8s.io/owners

--- a/etcdctl/diagnosis/README.md
+++ b/etcdctl/diagnosis/README.md
@@ -1,0 +1,31 @@
+# etcd-diagnosis
+
+`etcd-diagnosis` collects a set of troubleshooting details from every endpoint of an etcd cluster. When the `--offline` flag is specified it analyzes an etcd data directory instead.
+
+## Installation
+
+Install the tool by running the following command from the etcd source directory:
+
+```bash
+$ go install ./tools/etcd-diagnosis
+```
+
+## Usage
+
+```bash
+$ etcd-diagnosis --help
+```
+
+### Examples
+
+Run an online diagnosis against a running cluster:
+
+```bash
+$ etcd-diagnosis --endpoints=http://127.0.0.1:2379
+```
+
+Analyze data directory offline:
+
+```bash
+$ etcd-diagnosis --offline --data-dir /var/lib/etcd
+```

--- a/etcdctl/diagnosis/agent/agent.go
+++ b/etcdctl/diagnosis/agent/agent.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func MemberList(gcfg GlobalConfig, eps []string, options ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+	cfgSpec := clientConfigWithoutEndpoints(gcfg)
+	var err error
+	if len(eps) == 0 {
+		eps, err = endpointsFromCmd(gcfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cfgSpec.Endpoints = eps
+
+	c, err := createClient(cfgSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := commandCtx(gcfg.CommandTimeout)
+	defer func() {
+		c.Close()
+		cancel()
+	}()
+
+	members, err := c.MemberList(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return members, nil
+}
+
+func EndpointStatus(gcfg GlobalConfig, ep string) (*clientv3.StatusResponse, error) {
+	cfgSpec := clientConfigWithoutEndpoints(gcfg)
+	cfgSpec.Endpoints = []string{ep}
+	c, err := createClient(cfgSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to createClient: %w", err)
+	}
+
+	ctx, cancel := commandCtx(gcfg.CommandTimeout)
+	defer func() {
+		c.Close()
+		cancel()
+	}()
+	return c.Status(ctx, ep)
+}
+
+func Read(gcfg GlobalConfig, eps []string, key string, options ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	cfgSpec := clientConfigWithoutEndpoints(gcfg)
+	cfgSpec.Endpoints = eps
+	c, err := createClient(cfgSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to createClient: %w", err)
+	}
+
+	ctx, cancel := commandCtx(gcfg.CommandTimeout)
+	defer func() {
+		c.Close()
+		cancel()
+	}()
+
+	return c.Get(ctx, key, options...)
+}
+
+func Metrics(gcfg GlobalConfig, ep string) ([]string, error) {
+	if !strings.HasPrefix(ep, "http://") && !strings.HasPrefix(ep, "https://") {
+		ep = "http://" + ep
+	}
+	urlPath, err := url.JoinPath(ep, "metrics")
+	if err != nil {
+		return nil, fmt.Errorf("failed to join metrics url path: %w", err)
+	}
+
+	client := &http.Client{}
+	if strings.HasPrefix(urlPath, "https://") {
+		// load client certificate
+		cert, err := tls.LoadX509KeyPair(gcfg.CertFile, gcfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load certificate: %w", err)
+		}
+		// load CA
+		caCert, err := os.ReadFile(gcfg.CaFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates:       []tls.Certificate{cert},
+				RootCAs:            caCertPool,
+				InsecureSkipVerify: gcfg.InsecureSkipVerify,
+			},
+		}
+		client.Transport = tr
+	}
+	resp, err := client.Get(urlPath)
+	if err != nil {
+		return nil, fmt.Errorf("http get failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metrics response: %w", err)
+	}
+
+	return strings.Split(string(data), "\n"), nil
+}

--- a/etcdctl/diagnosis/agent/client.go
+++ b/etcdctl/diagnosis/agent/client.go
@@ -1,0 +1,38 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func commandCtx(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+func createClient(cfgSpec *clientv3.ConfigSpec) (*clientv3.Client, error) {
+	lg, _ := logutil.CreateDefaultZapLogger(zap.InfoLevel)
+	cfg, err := clientv3.NewClientConfig(cfgSpec, lg)
+	if err != nil {
+		return nil, err
+	}
+	return clientv3.New(*cfg)
+}

--- a/etcdctl/diagnosis/agent/config.go
+++ b/etcdctl/diagnosis/agent/config.go
@@ -1,0 +1,107 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type GlobalConfig struct {
+	Endpoints           []string `json:"endpoints,omitempty"`
+	UseClusterEndpoints bool     `json:"useClusterEndpoints,omitempty"`
+
+	DialTimeout      time.Duration `json:"dial-timeout,omitempty"`
+	CommandTimeout   time.Duration `json:"command-timeout,omitempty"`
+	KeepAliveTime    time.Duration `json:"keep-alive-time,omitempty"`
+	KeepAliveTimeout time.Duration `json:"keep-alive-timeout,omitempty"`
+
+	Insecure           bool `json:"insecure,omitempty"`
+	InsecureDiscovery  bool `json:"insecure-discovery,omitempty"`
+	InsecureSkipVerify bool `json:"insecure-skip-verify,omitempty"`
+
+	CertFile string `json:"cert-file,omitempty"`
+	KeyFile  string `json:"key-file,omitempty"`
+	CaFile   string `json:"ca-file,omitempty"`
+
+	DNSDomain  string `json:"dns-domain,omitempty"`
+	DNSService string `json:"dns-service,omitempty"`
+
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+
+	DbQuotaBytes int `json:"db-quota-bytes,omitempty"`
+
+	PrintVersion bool `json:"print-version,omitempty"`
+
+	Offline bool   `json:"offline,omitempty"`
+	DataDir string `json:"data-dir,omitempty"`
+}
+
+func clientConfigWithoutEndpoints(gcfg GlobalConfig) *clientv3.ConfigSpec {
+	cfg := &clientv3.ConfigSpec{
+		DialTimeout:      gcfg.DialTimeout,
+		KeepAliveTime:    gcfg.KeepAliveTime,
+		KeepAliveTimeout: gcfg.KeepAliveTimeout,
+
+		Secure: secureConfig(gcfg),
+		Auth:   authConfig(gcfg),
+	}
+
+	return cfg
+}
+
+func secureConfig(gcfg GlobalConfig) *clientv3.SecureConfig {
+	scfg := &clientv3.SecureConfig{
+		Cert:       gcfg.CertFile,
+		Key:        gcfg.KeyFile,
+		Cacert:     gcfg.CaFile,
+		ServerName: gcfg.DNSDomain,
+
+		InsecureTransport:  gcfg.Insecure,
+		InsecureSkipVerify: gcfg.InsecureSkipVerify,
+	}
+
+	if gcfg.InsecureDiscovery {
+		scfg.ServerName = ""
+	}
+
+	return scfg
+}
+
+func authConfig(gcfg GlobalConfig) *clientv3.AuthConfig {
+	if gcfg.Username == "" {
+		return nil
+	}
+
+	if gcfg.Password == "" {
+		userSecret := strings.SplitN(gcfg.Username, ":", 2)
+		if len(userSecret) < 2 {
+			return nil
+		}
+
+		return &clientv3.AuthConfig{
+			Username: userSecret[0],
+			Password: userSecret[1],
+		}
+	}
+
+	return &clientv3.AuthConfig{
+		Username: gcfg.Username,
+		Password: gcfg.Password,
+	}
+}

--- a/etcdctl/diagnosis/agent/endpoints.go
+++ b/etcdctl/diagnosis/agent/endpoints.go
@@ -1,0 +1,93 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.etcd.io/etcd/client/pkg/v3/srv"
+)
+
+func Endpoints(gcfg GlobalConfig) ([]string, error) {
+	if !gcfg.UseClusterEndpoints {
+		if len(gcfg.Endpoints) == 0 {
+			return nil, errors.New("no endpoints provided")
+		}
+		return gcfg.Endpoints, nil
+	}
+
+	return endpointsFromCluster(gcfg)
+}
+
+func endpointsFromCluster(gcfg GlobalConfig) ([]string, error) {
+	memberlistResp, err := MemberList(gcfg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var eps []string
+	for _, m := range memberlistResp.Members {
+		eps = append(eps, m.ClientURLs...)
+	}
+
+	return eps, nil
+}
+
+func endpointsFromCmd(gcfg GlobalConfig) ([]string, error) {
+	eps, err := endpointsFromDNSDiscovery(gcfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(eps) == 0 {
+		eps = gcfg.Endpoints
+	}
+
+	if len(eps) == 0 {
+		return nil, errors.New("no endpoints provided")
+	}
+
+	return eps, nil
+}
+
+func endpointsFromDNSDiscovery(gcfg GlobalConfig) ([]string, error) {
+	if gcfg.DNSDomain == "" {
+		return nil, nil
+	}
+
+	srvs, err := srv.GetClient("etcd-client", gcfg.DNSDomain, gcfg.DNSService)
+	if err != nil {
+		return nil, err
+	}
+
+	eps := srvs.Endpoints
+	if gcfg.InsecureDiscovery {
+		return eps, nil
+	}
+
+	// strip insecure connections
+	var ret []string
+	for _, ep := range eps {
+		if strings.HasPrefix(ep, "http://") {
+			fmt.Fprintf(os.Stderr, "ignoring discovered insecure endpoint %q\n", ep)
+			continue
+		}
+		ret = append(ret, ep)
+	}
+	return ret, nil
+}

--- a/etcdctl/diagnosis/cmd/root.go
+++ b/etcdctl/diagnosis/cmd/root.go
@@ -1,0 +1,86 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine"
+	intf "go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/offline"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/epstatus"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/membership"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/metrics"
+	readplugin "go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/read"
+)
+
+var diagCfg = agent.GlobalConfig{}
+
+// NewRootCommand returns the Cobra command for etcd-diagnosis.
+func NewRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "etcd-diagnosis",
+		Short: "One-stop etcd diagnosis tool",
+		Run:   runDiagnosis,
+	}
+
+	cmd.Flags().StringSliceVar(&diagCfg.Endpoints, "endpoints", []string{"127.0.0.1:2379"}, "comma separated etcd endpoints")
+	cmd.Flags().BoolVar(&diagCfg.UseClusterEndpoints, "cluster", false, "use all endpoints from the cluster member list")
+
+	cmd.Flags().DurationVar(&diagCfg.DialTimeout, "dial-timeout", 2*time.Second, "dial timeout for client connections")
+	cmd.Flags().DurationVar(&diagCfg.CommandTimeout, "command-timeout", 5*time.Second, "command timeout (excluding dial timeout)")
+	cmd.Flags().DurationVar(&diagCfg.KeepAliveTime, "keepalive-time", 2*time.Second, "keepalive time for client connections")
+	cmd.Flags().DurationVar(&diagCfg.KeepAliveTimeout, "keepalive-timeout", 5*time.Second, "keepalive timeout for client connections")
+
+	cmd.Flags().BoolVar(&diagCfg.Insecure, "insecure-transport", true, "disable transport security for client connections")
+	cmd.Flags().BoolVar(&diagCfg.InsecureSkipVerify, "insecure-skip-tls-verify", false, "skip server certificate verification")
+	cmd.Flags().StringVar(&diagCfg.CertFile, "cert", "", "identify secure client using this TLS certificate file")
+	cmd.Flags().StringVar(&diagCfg.KeyFile, "key", "", "identify secure client using this TLS key file")
+	cmd.Flags().StringVar(&diagCfg.CaFile, "cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle")
+
+	cmd.Flags().StringVar(&diagCfg.Username, "user", "", "username[:password] for authentication (prompt if password is not supplied)")
+	cmd.Flags().StringVar(&diagCfg.Password, "password", "", "password for authentication (if this option is used, --user option shouldn't include password)")
+	cmd.Flags().StringVarP(&diagCfg.DNSDomain, "discovery-srv", "d", "", "domain name to query for SRV records describing cluster endpoints")
+	cmd.Flags().StringVarP(&diagCfg.DNSService, "discovery-srv-name", "", "", "service name to query when using DNS discovery")
+	cmd.Flags().BoolVar(&diagCfg.InsecureDiscovery, "insecure-discovery", true, "accept insecure SRV records describing cluster endpoints")
+
+	cmd.Flags().IntVar(&diagCfg.DbQuotaBytes, "etcd-storage-quota-bytes", 2*1024*1024*1024, "etcd storage quota in bytes (the value passed to etcd instance by flag --quota-backend-bytes)")
+
+	cmd.Flags().BoolVar(&diagCfg.PrintVersion, "version", false, "print the version and exit")
+
+	cmd.Flags().BoolVar(&diagCfg.Offline, "offline", false, "offline analysis")
+	cmd.Flags().StringVar(&diagCfg.DataDir, "data-dir", "", "path to data directory")
+
+	return cmd
+}
+
+func runDiagnosis(cmd *cobra.Command, args []string) {
+	if diagCfg.Offline {
+		offline.AnalyzeOffline(diagCfg.DataDir)
+		return
+	}
+
+	plugins := []intf.Plugin{
+		membership.NewPlugin(diagCfg),
+		epstatus.NewPlugin(diagCfg),
+		readplugin.NewPlugin(diagCfg, false),
+		readplugin.NewPlugin(diagCfg, true),
+		metrics.NewPlugin(diagCfg),
+	}
+	engine.Diagnose(diagCfg, plugins)
+}

--- a/etcdctl/diagnosis/doc.go
+++ b/etcdctl/diagnosis/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// etcd-diagnosis is a comprehensive etcd troubleshooting tool.
+package main

--- a/etcdctl/diagnosis/engine/diagnosis.go
+++ b/etcdctl/diagnosis/engine/diagnosis.go
@@ -1,0 +1,61 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+)
+
+const (
+	reportFileName = "etcd_diagnosis_report.json"
+)
+
+type report struct {
+	Input   any   `json:"input,omitempty"`
+	Results []any `json:"results,omitempty"`
+}
+
+func Diagnose(input any, plugins []intf.Plugin) {
+	rp := report{
+		Input: input,
+	}
+	for i, plugin := range plugins {
+		log.Println("---------------------------------------------------------")
+		log.Printf("Running %q (%d/%d)...\n", plugin.Name(), i+1, len(plugins))
+
+		result := plugin.Diagnose()
+		rp.Results = append(rp.Results, result)
+
+		b, err := json.MarshalIndent(result, "", "\t")
+		if err != nil {
+			log.Printf("Failed to marshal result for plugin %q: %v", plugin.Name(), err)
+			continue
+		}
+		log.Println(string(b))
+	}
+
+	b, err := json.MarshalIndent(rp, "", "\t")
+	if err != nil {
+		log.Fatalf("Failed to marshal the report: %v", err)
+	}
+
+	if err := os.WriteFile(reportFileName, b, 0o644); err != nil {
+		log.Fatalf("Failed to write the report to file: %v", err)
+	}
+}

--- a/etcdctl/diagnosis/engine/intf/plugin.go
+++ b/etcdctl/diagnosis/engine/intf/plugin.go
@@ -1,0 +1,31 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intf
+
+type Plugin interface {
+	// Name returns the name of the plugin
+	Name() string
+	// Diagnose performs diagnosis and returns the result. If it fails
+	// to do the diagnosis for any reason, it gets the detailed reason
+	// included in the diagnosis result.
+	Diagnose() any
+}
+
+// FailedResult is the result returned by a plugin if it fails to
+// perform the diagnosis for any reason.
+type FailedResult struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}

--- a/etcdctl/diagnosis/main.go
+++ b/etcdctl/diagnosis/main.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/cmd"
+)
+
+func main() {
+	if err := cmd.NewRootCommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/etcdctl/diagnosis/offline/analysis.go
+++ b/etcdctl/diagnosis/offline/analysis.go
@@ -1,0 +1,107 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package offline
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sort"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+)
+
+var keyBucketName = []byte("key")
+
+type keyItem struct {
+	key      string
+	revCount int
+}
+
+type keyStats []keyItem
+
+func (ks keyStats) Len() int           { return len(ks) }
+func (ks keyStats) Less(i, j int) bool { return ks[i].revCount > ks[j].revCount }
+func (ks keyStats) Swap(i, j int)      { ks[i], ks[j] = ks[j], ks[i] }
+
+func AnalyzeOffline(dataDir string) {
+	log.Println("etcd diagnosis performs offline analysis...")
+
+	dbPath := ToBackendFileName(dataDir)
+	if !fileExists(dbPath) {
+		log.Printf("%s does not exist", dbPath)
+		return
+	}
+
+	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		log.Fatalf("Failed to open db: %s, error: %v", dbPath, err)
+	}
+
+	keyMap := make(map[string][]BucketKey)
+
+	_ = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(keyBucketName)
+
+		c := b.Cursor()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			rev := BytesToBucketKey(k)
+
+			kv := &mvccpb.KeyValue{}
+			if uerr := kv.Unmarshal(v); uerr != nil {
+				log.Printf("Failed to unmarshal key: %s, error: %v", string(k), uerr)
+			}
+
+			key := string(kv.Key)
+			if revList, ok := keyMap[key]; ok {
+				revList = append(revList, rev)
+				keyMap[key] = revList
+			} else {
+				keyMap[key] = []BucketKey{rev}
+			}
+		}
+
+		return nil
+	})
+
+	printStats(keyMap)
+}
+
+func printStats(keyMap map[string][]BucketKey) {
+	var allKeyStats []keyItem
+	for k, v := range keyMap {
+		allKeyStats = append(allKeyStats, keyItem{k, len(v)})
+	}
+	sort.Sort(keyStats(allKeyStats))
+
+	fmt.Println("All key stats:")
+	for _, k := range allKeyStats {
+		fmt.Printf("%s: %d\n", k.key, k.revCount)
+	}
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	log.Fatalf("Error checking file existence of %s: %v", filename, err)
+	return false
+}

--- a/etcdctl/diagnosis/offline/datadir.go
+++ b/etcdctl/diagnosis/offline/datadir.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package offline
+
+import "path/filepath"
+
+const (
+	memberDirSegment   = "member"
+	snapDirSegment     = "snap"
+	walDirSegment      = "wal"
+	backendFileSegment = "db"
+)
+
+func ToBackendFileName(dataDir string) string {
+	return filepath.Join(ToSnapDir(dataDir), backendFileSegment)
+}
+
+func ToSnapDir(dataDir string) string {
+	return filepath.Join(ToMemberDir(dataDir), snapDirSegment)
+}
+
+func ToWALDir(dataDir string) string {
+	return filepath.Join(ToMemberDir(dataDir), walDirSegment)
+}
+
+func ToMemberDir(dataDir string) string {
+	return filepath.Join(dataDir, memberDirSegment)
+}

--- a/etcdctl/diagnosis/offline/revision.go
+++ b/etcdctl/diagnosis/offline/revision.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package offline
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	// revBytesLen is the byte length of a normal revision.
+	// First 8 bytes is the revision.main in big-endian format. The 9th byte
+	// is a '_'. The last 8 bytes is the revision.sub in big-endian format.
+	revBytesLen = 8 + 1 + 8
+	// markedRevBytesLen is the byte length of marked revision.
+	// The first `revBytesLen` bytes represents a normal revision. The last
+	// one byte is the mark.
+	markedRevBytesLen      = revBytesLen + 1
+	markBytePosition       = markedRevBytesLen - 1
+	markTombstone     byte = 't'
+)
+
+type Revision struct {
+	// Main is the main revision of a set of changes that happen atomically.
+	Main int64
+	// Sub is the sub revision of a change in a set of changes that happen
+	// atomically. Each change has different increasing sub revision in that
+	// set.
+	Sub int64
+}
+
+// BucketKey indicates modification of the key-value space.
+// The set of changes that share same main revision changes the key-value space atomically.
+type BucketKey struct {
+	Revision
+	tombstone bool
+}
+
+func BytesToBucketKey(bytes []byte) BucketKey {
+	if (len(bytes) != revBytesLen) && (len(bytes) != markedRevBytesLen) {
+		panic(fmt.Sprintf("invalid revision length: %d", len(bytes)))
+	}
+	if bytes[8] != '_' {
+		panic(fmt.Sprintf("invalid separator in bucket key: %q", bytes[8]))
+	}
+	main := int64(binary.BigEndian.Uint64(bytes[0:8]))
+	sub := int64(binary.BigEndian.Uint64(bytes[9:]))
+	if main < 0 || sub < 0 {
+		panic(fmt.Sprintf("negative revision: main=%d sub=%d", main, sub))
+	}
+	return BucketKey{
+		Revision: Revision{
+			Main: main,
+			Sub:  sub,
+		},
+		tombstone: isTombstone(bytes),
+	}
+}
+
+func isTombstone(b []byte) bool {
+	return len(b) == markedRevBytesLen && b[markBytePosition] == markTombstone
+}

--- a/etcdctl/diagnosis/plugins/common/checker.go
+++ b/etcdctl/diagnosis/plugins/common/checker.go
@@ -1,0 +1,22 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+
+type Checker struct {
+	agent.GlobalConfig
+	Name string
+}

--- a/etcdctl/diagnosis/plugins/epstatus/plugin.go
+++ b/etcdctl/diagnosis/plugins/epstatus/plugin.go
@@ -1,0 +1,183 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package epstatus
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/common"
+)
+
+type epStatusChecker struct {
+	common.Checker
+}
+
+type epStatus struct {
+	Endpoint string                   `json:"endpoint,omitempty"`
+	EpStatus *clientv3.StatusResponse `json:"epStatus,omitempty"`
+}
+
+type checkResult struct {
+	Name         string     `json:"name,omitempty"`
+	Summary      []string   `json:"summary,omitempty"`
+	EpStatusList []epStatus `json:"epStatusList,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig) intf.Plugin {
+	return &epStatusChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         "epStatusChecker",
+		},
+	}
+}
+
+func (ck *epStatusChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func (ck *epStatusChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	var (
+		maxRetries  = 3
+		retries     = 0
+		shouldRetry = true
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+	)
+
+	for {
+		for i, ep := range eps {
+			chkResult.EpStatusList[i].Endpoint = ep
+			if chkResult.EpStatusList[i].EpStatus, err = agent.EndpointStatus(ck.GlobalConfig, ep); err != nil {
+				appendSummary(&chkResult, "Failed to get endpoint status from %q: %v", ep, err)
+				continue
+			}
+
+			if len(chkResult.EpStatusList[i].EpStatus.Errors) > 0 {
+				appendSummary(&chkResult, "Detected errors in endpoint %q: %v\n", ep, chkResult.EpStatusList[i].EpStatus.Errors)
+				shouldRetry = false
+				continue
+			}
+
+			if i > 0 {
+				if !compareHardInfo(chkResult.EpStatusList[0].EpStatus, chkResult.EpStatusList[i].EpStatus) {
+					appendSummary(&chkResult, "Detected inconsistent hard endpoint info between %q and %q\n", eps[0], eps[i])
+					shouldRetry = false
+				}
+
+				if !shouldRetry {
+					continue
+				}
+
+				if !compareSoftInfo(chkResult.EpStatusList[0].EpStatus, chkResult.EpStatusList[i].EpStatus) {
+					appendSummary(&chkResult, "Detected inconsistent soft endpoint info between %q and %q\n", eps[0], eps[i])
+				}
+			}
+		}
+
+		retries++
+
+		if len(chkResult.Summary) == 0 || !shouldRetry || retries >= maxRetries {
+			break
+		}
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+		log.Printf("Retrying checking endpoint status: %d/%d\n", retries, maxRetries)
+		time.Sleep(time.Second)
+	}
+
+	checkDBSize(&chkResult, ck.GlobalConfig)
+
+	if len(chkResult.Summary) == 0 {
+		chkResult.Summary = []string{"Successful"}
+	}
+
+	result = chkResult
+	return result
+}
+
+func initCheckResult(name string, epCount int) checkResult {
+	return checkResult{
+		Name:         name,
+		Summary:      []string{},
+		EpStatusList: make([]epStatus, epCount),
+	}
+}
+
+func appendSummary(chkResult *checkResult, format string, v ...any) {
+	errMsg := fmt.Sprintf(format, v...)
+	log.Println(errMsg)
+	chkResult.Summary = append(chkResult.Summary, errMsg)
+}
+
+func compareHardInfo(s1, s2 *clientv3.StatusResponse) bool {
+	if s1 == nil || s2 == nil {
+		return false
+	}
+	return s1.Header.ClusterId == s2.Header.ClusterId &&
+		s1.Version == s2.Version &&
+		s1.StorageVersion == s2.StorageVersion
+}
+
+func compareSoftInfo(s1, s2 *clientv3.StatusResponse) bool {
+	if s1 == nil || s2 == nil {
+		return false
+	}
+	return s1.Header.Revision == s2.Header.Revision &&
+		s1.RaftTerm == s2.RaftTerm &&
+		s1.RaftIndex == s2.RaftIndex &&
+		s1.RaftAppliedIndex == s2.RaftAppliedIndex &&
+		s1.Leader == s2.Leader
+}
+
+func checkDBSize(chkResult *checkResult, gcfg agent.GlobalConfig) {
+	for _, sts := range chkResult.EpStatusList {
+		if sts.EpStatus == nil {
+			continue
+		}
+
+		freeSize := sts.EpStatus.DbSize - sts.EpStatus.DbSizeInUse
+		// TODO: allow users to define rules?
+		if freeSize > sts.EpStatus.DbSizeInUse && freeSize > 1_000_000_000 /* about 1GB */ || sts.EpStatus.DbSize >= int64(gcfg.DbQuotaBytes*80/100) {
+			appendSummary(chkResult, "Detected large amount of db [free] space for endpoint %q, dbQuota: %d, dbSize: %d, dbSizeInUse: %d, dbSizeFree: %d", sts.Endpoint, gcfg.DbQuotaBytes, sts.EpStatus.DbSize, sts.EpStatus.DbSizeInUse, freeSize)
+		}
+	}
+}

--- a/etcdctl/diagnosis/plugins/membership/plugin.go
+++ b/etcdctl/diagnosis/plugins/membership/plugin.go
@@ -1,0 +1,113 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package membership
+
+import (
+	"log"
+	"reflect"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/common"
+)
+
+type membershipChecker struct {
+	common.Checker
+}
+
+type checkResult struct {
+	Name           string                         `json:"name,omitempty"`
+	Summary        string                         `json:"summary,omitempty"`
+	MemberList     *clientv3.MemberListResponse   `json:"memberList,omitempty"`
+	AllMemberLists []*clientv3.MemberListResponse `json:"allMemberLists,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig) intf.Plugin {
+	return &membershipChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         "membershipChecker",
+		},
+	}
+}
+
+func (ck *membershipChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func (ck *membershipChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	memberLists := make([]*clientv3.MemberListResponse, len(eps))
+	detectedInconsistency := false
+	for i, ep := range eps {
+		if memberLists[i], err = agent.MemberList(ck.GlobalConfig, []string{ep}, clientv3.WithSerializable()); err != nil {
+			detectedInconsistency = true
+			log.Printf("Failed to get member list from %q: %v\n", ep, err)
+			continue
+		}
+
+		if i > 0 {
+			if !compareMembers(memberLists[0], memberLists[i]) {
+				detectedInconsistency = true
+				log.Printf("Detected inconsistent member list between %q and %q\n", eps[0], eps[i])
+			}
+		}
+	}
+
+	if detectedInconsistency {
+		result = checkResult{
+			Name:           ck.Name(),
+			Summary:        "Detected inconsistent member list between different members",
+			AllMemberLists: memberLists,
+		}
+	} else {
+		result = checkResult{
+			Name:       ck.Name(),
+			Summary:    "Successful",
+			MemberList: memberLists[0],
+		}
+	}
+
+	return result
+}
+
+func compareMembers(m1, m2 *clientv3.MemberListResponse) bool {
+	if m1 == nil || m2 == nil {
+		return false
+	}
+
+	return m1.Header.ClusterId == m2.Header.ClusterId && reflect.DeepEqual(m1.Members, m2.Members)
+}

--- a/etcdctl/diagnosis/plugins/metrics/plugin.go
+++ b/etcdctl/diagnosis/plugins/metrics/plugin.go
@@ -1,0 +1,134 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/common"
+)
+
+var metricsNames = []string{
+	"etcd_disk_wal_fsync_duration_seconds_bucket",
+	"etcd_disk_backend_commit_duration_seconds_bucket",
+	"etcd_network_peer_round_trip_time_seconds_bucket",
+	"process_resident_memory_bytes",
+	//"process_cpu_seconds_total",
+}
+
+type metricsChecker struct {
+	common.Checker
+}
+
+type epMetrics struct {
+	Endpoint  string              `json:"endpoint,omitempty"`
+	Took      string              `json:"took,omitempty"`
+	EpMetrics map[string][]string `json:"epMetrics,omitempty"`
+}
+
+type checkResult struct {
+	Name          string      `json:"name,omitempty"`
+	Summary       []string    `json:"summary,omitempty"`
+	EpMetricsList []epMetrics `json:"epMetricsList,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig) intf.Plugin {
+	return &metricsChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         "metricsChecker",
+		},
+	}
+}
+
+func (ck *metricsChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func (ck *metricsChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	chkResult := checkResult{
+		Name:          ck.Name(),
+		Summary:       []string{},
+		EpMetricsList: make([]epMetrics, len(eps)),
+	}
+
+	for i, ep := range eps {
+		chkResult.EpMetricsList[i].Endpoint = ep
+
+		startTs := time.Now()
+		allMetrics, err := agent.Metrics(ck.GlobalConfig, ep)
+		chkResult.EpMetricsList[i].Took = time.Since(startTs).String()
+		if err != nil {
+			appendSummary(&chkResult, "Failed to get endpoint metrics from %q: %v", ep, err)
+			continue
+		}
+
+		metricsMap := map[string][]string{}
+		for _, prefix := range metricsNames {
+			ret := metrics(allMetrics, prefix)
+			metricsMap[prefix] = ret
+		}
+
+		chkResult.EpMetricsList[i].EpMetrics = metricsMap
+	}
+
+	if len(chkResult.Summary) == 0 {
+		chkResult.Summary = []string{"Successful"}
+	}
+
+	result = chkResult
+	return result
+}
+
+func metrics(lines []string, prefix string) []string {
+	var ret []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			ret = append(ret, line)
+		}
+	}
+	return ret
+}
+
+func appendSummary(chkResult *checkResult, format string, v ...any) {
+	errMsg := fmt.Sprintf(format, v...)
+	log.Println(errMsg)
+	chkResult.Summary = append(chkResult.Summary, errMsg)
+}

--- a/etcdctl/diagnosis/plugins/read/plugin.go
+++ b/etcdctl/diagnosis/plugins/read/plugin.go
@@ -1,0 +1,143 @@
+// Copyright 2025 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/agent"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/engine/intf"
+	"go.etcd.io/etcd/etcdctl/v3/diagnosis/plugins/common"
+)
+
+type readChecker struct {
+	common.Checker
+	linearizable bool
+}
+
+type readResponse struct {
+	Endpoint string `json:"endpoint,omitempty"`
+	Took     string `json:"took,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+type checkResult struct {
+	Name          string         `json:"name,omitempty"`
+	Summary       string         `json:"summary,omitempty"`
+	ReadResponses []readResponse `json:"readResponses,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig, linearizable bool) intf.Plugin {
+	return &readChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         generateName(linearizable),
+		},
+		linearizable: linearizable,
+	}
+}
+
+func (ck *readChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func generateName(linearizable bool) string {
+	if linearizable {
+		return "linearizableReadChecker"
+	}
+	return "serializableReadChecker"
+}
+
+func (ck *readChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	var (
+		maxRetries = 3
+		retries    = 0
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+	)
+
+	for {
+		shouldRetry := false
+		for i, ep := range eps {
+			chkResult.ReadResponses[i].Endpoint = ep
+
+			startTs := time.Now()
+			var err error
+			if ck.linearizable {
+				_, err = agent.Read(ck.GlobalConfig, []string{ep}, "health")
+			} else {
+				_, err = agent.Read(ck.GlobalConfig, []string{ep}, "health", clientv3.WithSerializable())
+			}
+			if err != nil && !errors.Is(err, rpctypes.ErrPermissionDenied) {
+				chkResult.ReadResponses[i].Error = err.Error()
+				shouldRetry = true
+			}
+			chkResult.ReadResponses[i].Took = time.Since(startTs).String()
+		}
+
+		retries++
+
+		if !shouldRetry || retries >= maxRetries {
+			break
+		}
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+		log.Printf("Retrying checking read: %d/%d\n", retries, maxRetries)
+		time.Sleep(time.Second)
+	}
+
+	chkResult.Summary = "Successful"
+	for _, resp := range chkResult.ReadResponses {
+		if len(resp.Error) > 0 {
+			chkResult.Summary = "Unsuccessful"
+			break
+		}
+	}
+
+	result = chkResult
+	return result
+}
+
+func initCheckResult(name string, epCount int) checkResult {
+	return checkResult{
+		Name:          name,
+		Summary:       "",
+		ReadResponses: make([]readResponse, epCount),
+	}
+}

--- a/etcdctl/go.mod
+++ b/etcdctl/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
+	go.etcd.io/bbolt v1.4.2
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/client/v3 v3.6.0-alpha.0

--- a/etcdctl/go.sum
+++ b/etcdctl/go.sum
@@ -84,6 +84,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.etcd.io/bbolt v1.4.2 h1:IrUHp260R8c+zYx/Tm8QZr04CX+qWS5PGfPdevhdm1I=
+go.etcd.io/bbolt v1.4.2/go.mod h1:Is8rSHO/b4f3XigBC0lL0+4FwAQv3HXEEIgFMuKHceM=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
@@ -116,6 +118,8 @@ golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tools/etcd-diagnosis/OWNERS
+++ b/tools/etcd-diagnosis/OWNERS
@@ -1,0 +1,1 @@
+# See the OWNERS docs at https://go.k8s.io/owners

--- a/tools/etcd-diagnosis/README.md
+++ b/tools/etcd-diagnosis/README.md
@@ -1,0 +1,31 @@
+# etcd-diagnosis
+
+`etcd-diagnosis` collects a set of troubleshooting details from every endpoint of an etcd cluster. When the `--offline` flag is specified it analyzes an etcd data directory instead.
+
+## Installation
+
+Install the tool by running the following command from the etcd source directory:
+
+```bash
+$ go install ./tools/etcd-diagnosis
+```
+
+## Usage
+
+```bash
+$ etcd-diagnosis --help
+```
+
+### Examples
+
+Run an online diagnosis against a running cluster:
+
+```bash
+$ etcd-diagnosis --endpoints=http://127.0.0.1:2379
+```
+
+Analyze data directory offline:
+
+```bash
+$ etcd-diagnosis --offline --data-dir /var/lib/etcd
+```

--- a/tools/etcd-diagnosis/agent/agent.go
+++ b/tools/etcd-diagnosis/agent/agent.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func MemberList(gcfg GlobalConfig, eps []string, options ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+	cfgSpec := clientConfigWithoutEndpoints(gcfg)
+	var err error
+	if len(eps) == 0 {
+		eps, err = endpointsFromCmd(gcfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cfgSpec.Endpoints = eps
+
+	c, err := createClient(cfgSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := commandCtx(gcfg.CommandTimeout)
+	defer func() {
+		c.Close()
+		cancel()
+	}()
+
+	members, err := c.MemberList(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return members, nil
+}
+
+func EndpointStatus(gcfg GlobalConfig, ep string) (*clientv3.StatusResponse, error) {
+	cfgSpec := clientConfigWithoutEndpoints(gcfg)
+	cfgSpec.Endpoints = []string{ep}
+	c, err := createClient(cfgSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to createClient: %w", err)
+	}
+
+	ctx, cancel := commandCtx(gcfg.CommandTimeout)
+	defer func() {
+		c.Close()
+		cancel()
+	}()
+	return c.Status(ctx, ep)
+}
+
+func Read(gcfg GlobalConfig, eps []string, key string, options ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	cfgSpec := clientConfigWithoutEndpoints(gcfg)
+	cfgSpec.Endpoints = eps
+	c, err := createClient(cfgSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to createClient: %w", err)
+	}
+
+	ctx, cancel := commandCtx(gcfg.CommandTimeout)
+	defer func() {
+		c.Close()
+		cancel()
+	}()
+
+	return c.Get(ctx, key, options...)
+}
+
+func Metrics(gcfg GlobalConfig, ep string) ([]string, error) {
+	if !strings.HasPrefix(ep, "http://") && !strings.HasPrefix(ep, "https://") {
+		ep = "http://" + ep
+	}
+	urlPath, err := url.JoinPath(ep, "metrics")
+	if err != nil {
+		return nil, fmt.Errorf("failed to join metrics url path: %w", err)
+	}
+
+	client := &http.Client{}
+	if strings.HasPrefix(urlPath, "https://") {
+		// load client certificate
+		cert, err := tls.LoadX509KeyPair(gcfg.CertFile, gcfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load certificate: %w", err)
+		}
+		// load CA
+		caCert, err := os.ReadFile(gcfg.CaFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates:       []tls.Certificate{cert},
+				RootCAs:            caCertPool,
+				InsecureSkipVerify: gcfg.InsecureSkipVerify,
+			},
+		}
+		client.Transport = tr
+	}
+	resp, err := client.Get(urlPath)
+	if err != nil {
+		return nil, fmt.Errorf("http get failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metrics response: %w", err)
+	}
+
+	return strings.Split(string(data), "\n"), nil
+}

--- a/tools/etcd-diagnosis/agent/client.go
+++ b/tools/etcd-diagnosis/agent/client.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func commandCtx(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+func createClient(cfgSpec *clientv3.ConfigSpec) (*clientv3.Client, error) {
+	lg, _ := logutil.CreateDefaultZapLogger(zap.InfoLevel)
+	cfg, err := clientv3.NewClientConfig(cfgSpec, lg)
+	if err != nil {
+		return nil, err
+	}
+	return clientv3.New(*cfg)
+}

--- a/tools/etcd-diagnosis/agent/config.go
+++ b/tools/etcd-diagnosis/agent/config.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type GlobalConfig struct {
+	Endpoints           []string `json:"endpoints,omitempty"`
+	UseClusterEndpoints bool     `json:"useClusterEndpoints,omitempty"`
+
+	DialTimeout      time.Duration `json:"dial-timeout,omitempty"`
+	CommandTimeout   time.Duration `json:"command-timeout,omitempty"`
+	KeepAliveTime    time.Duration `json:"keep-alive-time,omitempty"`
+	KeepAliveTimeout time.Duration `json:"keep-alive-timeout,omitempty"`
+
+	Insecure           bool `json:"insecure,omitempty"`
+	InsecureDiscovery  bool `json:"insecure-discovery,omitempty"`
+	InsecureSkipVerify bool `json:"insecure-skip-verify,omitempty"`
+
+	CertFile string `json:"cert-file,omitempty"`
+	KeyFile  string `json:"key-file,omitempty"`
+	CaFile   string `json:"ca-file,omitempty"`
+
+	DNSDomain  string `json:"dns-domain,omitempty"`
+	DNSService string `json:"dns-service,omitempty"`
+
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+
+	DbQuotaBytes int `json:"db-quota-bytes,omitempty"`
+
+	PrintVersion bool `json:"print-version,omitempty"`
+
+	Offline bool   `json:"offline,omitempty"`
+	DataDir string `json:"data-dir,omitempty"`
+}
+
+func clientConfigWithoutEndpoints(gcfg GlobalConfig) *clientv3.ConfigSpec {
+	cfg := &clientv3.ConfigSpec{
+		DialTimeout:      gcfg.DialTimeout,
+		KeepAliveTime:    gcfg.KeepAliveTime,
+		KeepAliveTimeout: gcfg.KeepAliveTimeout,
+
+		Secure: secureConfig(gcfg),
+		Auth:   authConfig(gcfg),
+	}
+
+	return cfg
+}
+
+func secureConfig(gcfg GlobalConfig) *clientv3.SecureConfig {
+	scfg := &clientv3.SecureConfig{
+		Cert:       gcfg.CertFile,
+		Key:        gcfg.KeyFile,
+		Cacert:     gcfg.CaFile,
+		ServerName: gcfg.DNSDomain,
+
+		InsecureTransport:  gcfg.Insecure,
+		InsecureSkipVerify: gcfg.InsecureSkipVerify,
+	}
+
+	if gcfg.InsecureDiscovery {
+		scfg.ServerName = ""
+	}
+
+	return scfg
+}
+
+func authConfig(gcfg GlobalConfig) *clientv3.AuthConfig {
+	if gcfg.Username == "" {
+		return nil
+	}
+
+	if gcfg.Password == "" {
+		userSecret := strings.SplitN(gcfg.Username, ":", 2)
+		if len(userSecret) < 2 {
+			return nil
+		}
+
+		return &clientv3.AuthConfig{
+			Username: userSecret[0],
+			Password: userSecret[1],
+		}
+	}
+
+	return &clientv3.AuthConfig{
+		Username: gcfg.Username,
+		Password: gcfg.Password,
+	}
+}

--- a/tools/etcd-diagnosis/agent/endpoints.go
+++ b/tools/etcd-diagnosis/agent/endpoints.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.etcd.io/etcd/client/pkg/v3/srv"
+)
+
+func Endpoints(gcfg GlobalConfig) ([]string, error) {
+	if !gcfg.UseClusterEndpoints {
+		if len(gcfg.Endpoints) == 0 {
+			return nil, errors.New("no endpoints provided")
+		}
+		return gcfg.Endpoints, nil
+	}
+
+	return endpointsFromCluster(gcfg)
+}
+
+func endpointsFromCluster(gcfg GlobalConfig) ([]string, error) {
+	memberlistResp, err := MemberList(gcfg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var eps []string
+	for _, m := range memberlistResp.Members {
+		eps = append(eps, m.ClientURLs...)
+	}
+
+	return eps, nil
+}
+
+func endpointsFromCmd(gcfg GlobalConfig) ([]string, error) {
+	eps, err := endpointsFromDNSDiscovery(gcfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(eps) == 0 {
+		eps = gcfg.Endpoints
+	}
+
+	if len(eps) == 0 {
+		return nil, errors.New("no endpoints provided")
+	}
+
+	return eps, nil
+}
+
+func endpointsFromDNSDiscovery(gcfg GlobalConfig) ([]string, error) {
+	if gcfg.DNSDomain == "" {
+		return nil, nil
+	}
+
+	srvs, err := srv.GetClient("etcd-client", gcfg.DNSDomain, gcfg.DNSService)
+	if err != nil {
+		return nil, err
+	}
+
+	eps := srvs.Endpoints
+	if gcfg.InsecureDiscovery {
+		return eps, nil
+	}
+
+	// strip insecure connections
+	var ret []string
+	for _, ep := range eps {
+		if strings.HasPrefix(ep, "http://") {
+			fmt.Fprintf(os.Stderr, "ignoring discovered insecure endpoint %q\n", ep)
+			continue
+		}
+		ret = append(ret, ep)
+	}
+	return ret, nil
+}

--- a/tools/etcd-diagnosis/cmd/root.go
+++ b/tools/etcd-diagnosis/cmd/root.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/agent"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine"
+	intf "go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine/intf"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/offline"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/epstatus"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/membership"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/metrics"
+	readplugin "go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/read"
+)
+
+var diagCfg = agent.GlobalConfig{}
+
+// NewRootCommand returns the Cobra command for etcd-diagnosis.
+func NewRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "etcd-diagnosis",
+		Short: "One-stop etcd diagnosis tool",
+		Run:   runDiagnosis,
+	}
+
+	cmd.Flags().StringSliceVar(&diagCfg.Endpoints, "endpoints", []string{"127.0.0.1:2379"}, "comma separated etcd endpoints")
+	cmd.Flags().BoolVar(&diagCfg.UseClusterEndpoints, "cluster", false, "use all endpoints from the cluster member list")
+
+	cmd.Flags().DurationVar(&diagCfg.DialTimeout, "dial-timeout", 2*time.Second, "dial timeout for client connections")
+	cmd.Flags().DurationVar(&diagCfg.CommandTimeout, "command-timeout", 5*time.Second, "command timeout (excluding dial timeout)")
+	cmd.Flags().DurationVar(&diagCfg.KeepAliveTime, "keepalive-time", 2*time.Second, "keepalive time for client connections")
+	cmd.Flags().DurationVar(&diagCfg.KeepAliveTimeout, "keepalive-timeout", 5*time.Second, "keepalive timeout for client connections")
+
+	cmd.Flags().BoolVar(&diagCfg.Insecure, "insecure-transport", true, "disable transport security for client connections")
+	cmd.Flags().BoolVar(&diagCfg.InsecureSkipVerify, "insecure-skip-tls-verify", false, "skip server certificate verification")
+	cmd.Flags().StringVar(&diagCfg.CertFile, "cert", "", "identify secure client using this TLS certificate file")
+	cmd.Flags().StringVar(&diagCfg.KeyFile, "key", "", "identify secure client using this TLS key file")
+	cmd.Flags().StringVar(&diagCfg.CaFile, "cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle")
+
+	cmd.Flags().StringVar(&diagCfg.Username, "user", "", "username[:password] for authentication (prompt if password is not supplied)")
+	cmd.Flags().StringVar(&diagCfg.Password, "password", "", "password for authentication (if this option is used, --user option shouldn't include password)")
+	cmd.Flags().StringVarP(&diagCfg.DNSDomain, "discovery-srv", "d", "", "domain name to query for SRV records describing cluster endpoints")
+	cmd.Flags().StringVarP(&diagCfg.DNSService, "discovery-srv-name", "", "", "service name to query when using DNS discovery")
+	cmd.Flags().BoolVar(&diagCfg.InsecureDiscovery, "insecure-discovery", true, "accept insecure SRV records describing cluster endpoints")
+
+	cmd.Flags().IntVar(&diagCfg.DbQuotaBytes, "etcd-storage-quota-bytes", 2*1024*1024*1024, "etcd storage quota in bytes (the value passed to etcd instance by flag --quota-backend-bytes)")
+
+	cmd.Flags().BoolVar(&diagCfg.PrintVersion, "version", false, "print the version and exit")
+
+	cmd.Flags().BoolVar(&diagCfg.Offline, "offline", false, "offline analysis")
+	cmd.Flags().StringVar(&diagCfg.DataDir, "data-dir", "", "path to data directory")
+
+	return cmd
+}
+
+func runDiagnosis(cmd *cobra.Command, args []string) {
+	if diagCfg.Offline {
+		offline.AnalyzeOffline(diagCfg.DataDir)
+		return
+	}
+
+	plugins := []intf.Plugin{
+		membership.NewPlugin(diagCfg),
+		epstatus.NewPlugin(diagCfg),
+		readplugin.NewPlugin(diagCfg, false),
+		readplugin.NewPlugin(diagCfg, true),
+		metrics.NewPlugin(diagCfg),
+	}
+	engine.Diagnose(diagCfg, plugins)
+}

--- a/tools/etcd-diagnosis/doc.go
+++ b/tools/etcd-diagnosis/doc.go
@@ -1,0 +1,2 @@
+// etcd-diagnosis is a comprehensive etcd troubleshooting tool.
+package main

--- a/tools/etcd-diagnosis/engine/diagnosis.go
+++ b/tools/etcd-diagnosis/engine/diagnosis.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine/intf"
+)
+
+const (
+	reportFileName = "etcd_diagnosis_report.json"
+)
+
+type report struct {
+	Input   any   `json:"input,omitempty"`
+	Results []any `json:"results,omitempty"`
+}
+
+func Diagnose(input any, plugins []intf.Plugin) {
+	rp := report{
+		Input: input,
+	}
+	for i, plugin := range plugins {
+		log.Println("---------------------------------------------------------")
+		log.Printf("Running %q (%d/%d)...\n", plugin.Name(), i+1, len(plugins))
+
+		result := plugin.Diagnose()
+		rp.Results = append(rp.Results, result)
+
+		b, err := json.MarshalIndent(result, "", "\t")
+		if err != nil {
+			log.Printf("Failed to marshal result for plugin %q: %v", plugin.Name(), err)
+			continue
+		}
+		log.Println(string(b))
+	}
+
+	b, err := json.MarshalIndent(rp, "", "\t")
+	if err != nil {
+		log.Fatalf("Failed to marshal the report: %v", err)
+	}
+
+	if err := os.WriteFile(reportFileName, b, 0o644); err != nil {
+		log.Fatalf("Failed to write the report to file: %v", err)
+	}
+}

--- a/tools/etcd-diagnosis/engine/intf/plugin.go
+++ b/tools/etcd-diagnosis/engine/intf/plugin.go
@@ -1,0 +1,17 @@
+package intf
+
+type Plugin interface {
+	// Name returns the name of the plugin
+	Name() string
+	// Diagnose performs diagnosis and returns the result. If it fails
+	// to do the diagnosis for any reason, it gets the detailed reason
+	// included in the diagnosis result.
+	Diagnose() any
+}
+
+// FailedResult is the result returned by a plugin if it fails to
+// perform the diagnosis for any reason.
+type FailedResult struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}

--- a/tools/etcd-diagnosis/main.go
+++ b/tools/etcd-diagnosis/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/cmd"
+)
+
+func main() {
+	if err := cmd.NewRootCommand().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/tools/etcd-diagnosis/offline/analysis.go
+++ b/tools/etcd-diagnosis/offline/analysis.go
@@ -1,0 +1,93 @@
+package offline
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sort"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+)
+
+var keyBucketName = []byte("key")
+
+type keyItem struct {
+	key      string
+	revCount int
+}
+
+type keyStats []keyItem
+
+func (ks keyStats) Len() int           { return len(ks) }
+func (ks keyStats) Less(i, j int) bool { return ks[i].revCount > ks[j].revCount }
+func (ks keyStats) Swap(i, j int)      { ks[i], ks[j] = ks[j], ks[i] }
+
+func AnalyzeOffline(dataDir string) {
+	log.Println("etcd diagnosis performs offline analysis...")
+
+	dbPath := ToBackendFileName(dataDir)
+	if !fileExists(dbPath) {
+		log.Printf("%s does not exist", dbPath)
+		return
+	}
+
+	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		log.Fatalf("Failed to open db: %s, error: %v", dbPath, err)
+	}
+
+	keyMap := make(map[string][]BucketKey)
+
+	_ = db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(keyBucketName)
+
+		c := b.Cursor()
+
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			rev := BytesToBucketKey(k)
+
+			kv := &mvccpb.KeyValue{}
+			if uerr := kv.Unmarshal(v); uerr != nil {
+				log.Printf("Failed to unmarshal key: %s, error: %v", string(k), uerr)
+			}
+
+			key := string(kv.Key)
+			if revList, ok := keyMap[key]; ok {
+				revList = append(revList, rev)
+				keyMap[key] = revList
+			} else {
+				keyMap[key] = []BucketKey{rev}
+			}
+		}
+
+		return nil
+	})
+
+	printStats(keyMap)
+}
+
+func printStats(keyMap map[string][]BucketKey) {
+	var allKeyStats []keyItem
+	for k, v := range keyMap {
+		allKeyStats = append(allKeyStats, keyItem{k, len(v)})
+	}
+	sort.Sort(keyStats(allKeyStats))
+
+	fmt.Println("All key stats:")
+	for _, k := range allKeyStats {
+		fmt.Printf("%s: %d\n", k.key, k.revCount)
+	}
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	log.Fatalf("Error checking file existence of %s: %v", filename, err)
+	return false
+}

--- a/tools/etcd-diagnosis/offline/datadir.go
+++ b/tools/etcd-diagnosis/offline/datadir.go
@@ -1,0 +1,26 @@
+package offline
+
+import "path/filepath"
+
+const (
+	memberDirSegment   = "member"
+	snapDirSegment     = "snap"
+	walDirSegment      = "wal"
+	backendFileSegment = "db"
+)
+
+func ToBackendFileName(dataDir string) string {
+	return filepath.Join(ToSnapDir(dataDir), backendFileSegment)
+}
+
+func ToSnapDir(dataDir string) string {
+	return filepath.Join(ToMemberDir(dataDir), snapDirSegment)
+}
+
+func ToWALDir(dataDir string) string {
+	return filepath.Join(ToMemberDir(dataDir), walDirSegment)
+}
+
+func ToMemberDir(dataDir string) string {
+	return filepath.Join(dataDir, memberDirSegment)
+}

--- a/tools/etcd-diagnosis/offline/revision.go
+++ b/tools/etcd-diagnosis/offline/revision.go
@@ -1,0 +1,60 @@
+package offline
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	// revBytesLen is the byte length of a normal revision.
+	// First 8 bytes is the revision.main in big-endian format. The 9th byte
+	// is a '_'. The last 8 bytes is the revision.sub in big-endian format.
+	revBytesLen = 8 + 1 + 8
+	// markedRevBytesLen is the byte length of marked revision.
+	// The first `revBytesLen` bytes represents a normal revision. The last
+	// one byte is the mark.
+	markedRevBytesLen      = revBytesLen + 1
+	markBytePosition       = markedRevBytesLen - 1
+	markTombstone     byte = 't'
+)
+
+type Revision struct {
+	// Main is the main revision of a set of changes that happen atomically.
+	Main int64
+	// Sub is the sub revision of a change in a set of changes that happen
+	// atomically. Each change has different increasing sub revision in that
+	// set.
+	Sub int64
+}
+
+// BucketKey indicates modification of the key-value space.
+// The set of changes that share same main revision changes the key-value space atomically.
+type BucketKey struct {
+	Revision
+	tombstone bool
+}
+
+func BytesToBucketKey(bytes []byte) BucketKey {
+	if (len(bytes) != revBytesLen) && (len(bytes) != markedRevBytesLen) {
+		panic(fmt.Sprintf("invalid revision length: %d", len(bytes)))
+	}
+	if bytes[8] != '_' {
+		panic(fmt.Sprintf("invalid separator in bucket key: %q", bytes[8]))
+	}
+	main := int64(binary.BigEndian.Uint64(bytes[0:8]))
+	sub := int64(binary.BigEndian.Uint64(bytes[9:]))
+	if main < 0 || sub < 0 {
+		panic(fmt.Sprintf("negative revision: main=%d sub=%d", main, sub))
+	}
+	return BucketKey{
+		Revision: Revision{
+			Main: main,
+			Sub:  sub,
+		},
+		tombstone: isTombstone(bytes),
+	}
+}
+
+func isTombstone(b []byte) bool {
+	return len(b) == markedRevBytesLen && b[markBytePosition] == markTombstone
+}

--- a/tools/etcd-diagnosis/plugins/common/checker.go
+++ b/tools/etcd-diagnosis/plugins/common/checker.go
@@ -1,0 +1,8 @@
+package common
+
+import "go.etcd.io/etcd/v3/tools/etcd-diagnosis/agent"
+
+type Checker struct {
+	agent.GlobalConfig
+	Name string
+}

--- a/tools/etcd-diagnosis/plugins/epstatus/plugin.go
+++ b/tools/etcd-diagnosis/plugins/epstatus/plugin.go
@@ -1,0 +1,169 @@
+package epstatus
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/agent"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine/intf"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/common"
+)
+
+type epStatusChecker struct {
+	common.Checker
+}
+
+type epStatus struct {
+	Endpoint string                   `json:"endpoint,omitempty"`
+	EpStatus *clientv3.StatusResponse `json:"epStatus,omitempty"`
+}
+
+type checkResult struct {
+	Name         string     `json:"name,omitempty"`
+	Summary      []string   `json:"summary,omitempty"`
+	EpStatusList []epStatus `json:"epStatusList,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig) intf.Plugin {
+	return &epStatusChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         "epStatusChecker",
+		},
+	}
+}
+
+func (ck *epStatusChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func (ck *epStatusChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	var (
+		maxRetries  = 3
+		retries     = 0
+		shouldRetry = true
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+	)
+
+	for {
+		for i, ep := range eps {
+			chkResult.EpStatusList[i].Endpoint = ep
+			if chkResult.EpStatusList[i].EpStatus, err = agent.EndpointStatus(ck.GlobalConfig, ep); err != nil {
+				appendSummary(&chkResult, "Failed to get endpoint status from %q: %v", ep, err)
+				continue
+			}
+
+			if len(chkResult.EpStatusList[i].EpStatus.Errors) > 0 {
+				appendSummary(&chkResult, "Detected errors in endpoint %q: %v\n", ep, chkResult.EpStatusList[i].EpStatus.Errors)
+				shouldRetry = false
+				continue
+			}
+
+			if i > 0 {
+				if !compareHardInfo(chkResult.EpStatusList[0].EpStatus, chkResult.EpStatusList[i].EpStatus) {
+					appendSummary(&chkResult, "Detected inconsistent hard endpoint info between %q and %q\n", eps[0], eps[i])
+					shouldRetry = false
+				}
+
+				if !shouldRetry {
+					continue
+				}
+
+				if !compareSoftInfo(chkResult.EpStatusList[0].EpStatus, chkResult.EpStatusList[i].EpStatus) {
+					appendSummary(&chkResult, "Detected inconsistent soft endpoint info between %q and %q\n", eps[0], eps[i])
+				}
+			}
+		}
+
+		retries++
+
+		if len(chkResult.Summary) == 0 || !shouldRetry || retries >= maxRetries {
+			break
+		}
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+		log.Printf("Retrying checking endpoint status: %d/%d\n", retries, maxRetries)
+		time.Sleep(time.Second)
+	}
+
+	checkDBSize(&chkResult, ck.GlobalConfig)
+
+	if len(chkResult.Summary) == 0 {
+		chkResult.Summary = []string{"Successful"}
+	}
+
+	result = chkResult
+	return result
+}
+
+func initCheckResult(name string, epCount int) checkResult {
+	return checkResult{
+		Name:         name,
+		Summary:      []string{},
+		EpStatusList: make([]epStatus, epCount),
+	}
+}
+
+func appendSummary(chkResult *checkResult, format string, v ...any) {
+	errMsg := fmt.Sprintf(format, v...)
+	log.Println(errMsg)
+	chkResult.Summary = append(chkResult.Summary, errMsg)
+}
+
+func compareHardInfo(s1, s2 *clientv3.StatusResponse) bool {
+	if s1 == nil || s2 == nil {
+		return false
+	}
+	return s1.Header.ClusterId == s2.Header.ClusterId &&
+		s1.Version == s2.Version &&
+		s1.StorageVersion == s2.StorageVersion
+}
+
+func compareSoftInfo(s1, s2 *clientv3.StatusResponse) bool {
+	if s1 == nil || s2 == nil {
+		return false
+	}
+	return s1.Header.Revision == s2.Header.Revision &&
+		s1.RaftTerm == s2.RaftTerm &&
+		s1.RaftIndex == s2.RaftIndex &&
+		s1.RaftAppliedIndex == s2.RaftAppliedIndex &&
+		s1.Leader == s2.Leader
+}
+
+func checkDBSize(chkResult *checkResult, gcfg agent.GlobalConfig) {
+	for _, sts := range chkResult.EpStatusList {
+		if sts.EpStatus == nil {
+			continue
+		}
+
+		freeSize := sts.EpStatus.DbSize - sts.EpStatus.DbSizeInUse
+		// TODO: allow users to define rules?
+		if freeSize > sts.EpStatus.DbSizeInUse && freeSize > 1_000_000_000 /* about 1GB */ || sts.EpStatus.DbSize >= int64(gcfg.DbQuotaBytes*80/100) {
+			appendSummary(chkResult, "Detected large amount of db [free] space for endpoint %q, dbQuota: %d, dbSize: %d, dbSizeInUse: %d, dbSizeFree: %d", sts.Endpoint, gcfg.DbQuotaBytes, sts.EpStatus.DbSize, sts.EpStatus.DbSizeInUse, freeSize)
+		}
+	}
+}

--- a/tools/etcd-diagnosis/plugins/membership/plugin.go
+++ b/tools/etcd-diagnosis/plugins/membership/plugin.go
@@ -1,0 +1,99 @@
+package membership
+
+import (
+	"log"
+	"reflect"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/agent"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine/intf"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/common"
+)
+
+type membershipChecker struct {
+	common.Checker
+}
+
+type checkResult struct {
+	Name           string                         `json:"name,omitempty"`
+	Summary        string                         `json:"summary,omitempty"`
+	MemberList     *clientv3.MemberListResponse   `json:"memberList,omitempty"`
+	AllMemberLists []*clientv3.MemberListResponse `json:"allMemberLists,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig) intf.Plugin {
+	return &membershipChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         "membershipChecker",
+		},
+	}
+}
+
+func (ck *membershipChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func (ck *membershipChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	memberLists := make([]*clientv3.MemberListResponse, len(eps))
+	detectedInconsistency := false
+	for i, ep := range eps {
+		if memberLists[i], err = agent.MemberList(ck.GlobalConfig, []string{ep}, clientv3.WithSerializable()); err != nil {
+			detectedInconsistency = true
+			log.Printf("Failed to get member list from %q: %v\n", ep, err)
+			continue
+		}
+
+		if i > 0 {
+			if !compareMembers(memberLists[0], memberLists[i]) {
+				detectedInconsistency = true
+				log.Printf("Detected inconsistent member list between %q and %q\n", eps[0], eps[i])
+			}
+		}
+	}
+
+	if detectedInconsistency {
+		result = checkResult{
+			Name:           ck.Name(),
+			Summary:        "Detected inconsistent member list between different members",
+			AllMemberLists: memberLists,
+		}
+	} else {
+		result = checkResult{
+			Name:       ck.Name(),
+			Summary:    "Successful",
+			MemberList: memberLists[0],
+		}
+	}
+
+	return result
+}
+
+func compareMembers(m1, m2 *clientv3.MemberListResponse) bool {
+	if m1 == nil || m2 == nil {
+		return false
+	}
+
+	return m1.Header.ClusterId == m2.Header.ClusterId && reflect.DeepEqual(m1.Members, m2.Members)
+}

--- a/tools/etcd-diagnosis/plugins/metrics/plugin.go
+++ b/tools/etcd-diagnosis/plugins/metrics/plugin.go
@@ -1,0 +1,120 @@
+package metrics
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/agent"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine/intf"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/common"
+)
+
+var metricsNames = []string{
+	"etcd_disk_wal_fsync_duration_seconds_bucket",
+	"etcd_disk_backend_commit_duration_seconds_bucket",
+	"etcd_network_peer_round_trip_time_seconds_bucket",
+	"process_resident_memory_bytes",
+	//"process_cpu_seconds_total",
+}
+
+type metricsChecker struct {
+	common.Checker
+}
+
+type epMetrics struct {
+	Endpoint  string              `json:"endpoint,omitempty"`
+	Took      string              `json:"took,omitempty"`
+	EpMetrics map[string][]string `json:"epMetrics,omitempty"`
+}
+
+type checkResult struct {
+	Name          string      `json:"name,omitempty"`
+	Summary       []string    `json:"summary,omitempty"`
+	EpMetricsList []epMetrics `json:"epMetricsList,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig) intf.Plugin {
+	return &metricsChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         "metricsChecker",
+		},
+	}
+}
+
+func (ck *metricsChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func (ck *metricsChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	chkResult := checkResult{
+		Name:          ck.Name(),
+		Summary:       []string{},
+		EpMetricsList: make([]epMetrics, len(eps)),
+	}
+
+	for i, ep := range eps {
+		chkResult.EpMetricsList[i].Endpoint = ep
+
+		startTs := time.Now()
+		allMetrics, err := agent.Metrics(ck.GlobalConfig, ep)
+		chkResult.EpMetricsList[i].Took = time.Since(startTs).String()
+		if err != nil {
+			appendSummary(&chkResult, "Failed to get endpoint metrics from %q: %v", ep, err)
+			continue
+		}
+
+		metricsMap := map[string][]string{}
+		for _, prefix := range metricsNames {
+			ret := metrics(allMetrics, prefix)
+			metricsMap[prefix] = ret
+		}
+
+		chkResult.EpMetricsList[i].EpMetrics = metricsMap
+	}
+
+	if len(chkResult.Summary) == 0 {
+		chkResult.Summary = []string{"Successful"}
+	}
+
+	result = chkResult
+	return result
+}
+
+func metrics(lines []string, prefix string) []string {
+	var ret []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			ret = append(ret, line)
+		}
+	}
+	return ret
+}
+
+func appendSummary(chkResult *checkResult, format string, v ...any) {
+	errMsg := fmt.Sprintf(format, v...)
+	log.Println(errMsg)
+	chkResult.Summary = append(chkResult.Summary, errMsg)
+}

--- a/tools/etcd-diagnosis/plugins/read/plugin.go
+++ b/tools/etcd-diagnosis/plugins/read/plugin.go
@@ -1,0 +1,129 @@
+package read
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/agent"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/engine/intf"
+	"go.etcd.io/etcd/v3/tools/etcd-diagnosis/plugins/common"
+)
+
+type readChecker struct {
+	common.Checker
+	linearizable bool
+}
+
+type readResponse struct {
+	Endpoint string `json:"endpoint,omitempty"`
+	Took     string `json:"took,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+type checkResult struct {
+	Name          string         `json:"name,omitempty"`
+	Summary       string         `json:"summary,omitempty"`
+	ReadResponses []readResponse `json:"readResponses,omitempty"`
+}
+
+func NewPlugin(gcfg agent.GlobalConfig, linearizable bool) intf.Plugin {
+	return &readChecker{
+		Checker: common.Checker{
+			GlobalConfig: gcfg,
+			Name:         generateName(linearizable),
+		},
+		linearizable: linearizable,
+	}
+}
+
+func (ck *readChecker) Name() string {
+	return ck.Checker.Name
+}
+
+func generateName(linearizable bool) string {
+	if linearizable {
+		return "linearizableReadChecker"
+	}
+	return "serializableReadChecker"
+}
+
+func (ck *readChecker) Diagnose() (result any) {
+	var (
+		eps []string
+		err error
+	)
+
+	defer func() {
+		if err != nil {
+			result = &intf.FailedResult{
+				Name:   ck.Name(),
+				Reason: err.Error(),
+			}
+		}
+	}()
+
+	if eps, err = agent.Endpoints(ck.GlobalConfig); err != nil {
+		log.Printf("Failed to get endpoint: %v\n", err)
+		return result
+	}
+	log.Printf("Endpoints: %v\n", eps)
+
+	var (
+		maxRetries = 3
+		retries    = 0
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+	)
+
+	for {
+		shouldRetry := false
+		for i, ep := range eps {
+			chkResult.ReadResponses[i].Endpoint = ep
+
+			startTs := time.Now()
+			var err error
+			if ck.linearizable {
+				_, err = agent.Read(ck.GlobalConfig, []string{ep}, "health")
+			} else {
+				_, err = agent.Read(ck.GlobalConfig, []string{ep}, "health", clientv3.WithSerializable())
+			}
+			if err != nil && !errors.Is(err, rpctypes.ErrPermissionDenied) {
+				chkResult.ReadResponses[i].Error = err.Error()
+				shouldRetry = true
+			}
+			chkResult.ReadResponses[i].Took = time.Since(startTs).String()
+		}
+
+		retries++
+
+		if !shouldRetry || retries >= maxRetries {
+			break
+		}
+
+		chkResult = initCheckResult(ck.Name(), len(eps))
+		log.Printf("Retrying checking read: %d/%d\n", retries, maxRetries)
+		time.Sleep(time.Second)
+	}
+
+	chkResult.Summary = "Successful"
+	for _, resp := range chkResult.ReadResponses {
+		if len(resp.Error) > 0 {
+			chkResult.Summary = "Unsuccessful"
+			break
+		}
+	}
+
+	result = chkResult
+	return result
+}
+
+func initCheckResult(name string, epCount int) checkResult {
+	return checkResult{
+		Name:          name,
+		Summary:       "",
+		ReadResponses: make([]readResponse, epCount),
+	}
+}


### PR DESCRIPTION
## Summary
- add `diagnosis` subcommand to gather troubleshooting data from cluster
- implement agent, engine and plugins under `etcdctl/diagnosis`
- allow offline analysis of data directories
- document the new command in `etcdctl/README.md`
- ensure `make verify` installs correct golangci-lint version
- fix error handling in read plugins

## Testing
- `make verify`


------
https://chatgpt.com/codex/tasks/task_e_6863d4c12ac083229ca0fd1e343a624a